### PR TITLE
Automate insp update

### DIFF
--- a/.github/workflows/auto_insp_update.yml
+++ b/.github/workflows/auto_insp_update.yml
@@ -1,0 +1,38 @@
+# Try to automatically update papers from INSPIRE
+
+name: Attempt to automatically update papers
+
+on:
+  workflow_dispatch: # This allows us to manually trigger
+  schedule:
+    # Hour 11 of every day
+    - cron: "0 11 * * *"
+
+jobs:
+  update:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install sxs dateparser
+    - name: Run inspSXSUpdateByDate
+      run: |
+        cd _papers
+        python inspSXSUpdateByDate.py
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v7
+      with:
+        branch: gh-action/autoINSPUpdate
+        add-paths: _papers/*.md
+        delete-branch: true
+        commit-message: Auto paper update
+        title: "Attempt to auto update papers from INSPIRE"
+        body: "New paper updates found!"

--- a/_papers/inspSXSUpdateByDate.py
+++ b/_papers/inspSXSUpdateByDate.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import argparse
+
+import dateparser
+
+import sxs
+
+from inspToMd import write_insp_resp_to_md
+
+sxs_insp_names = [
+    # Faculty
+    "Nils.Deppe.1",
+    "M.D.Duez.5",
+    "S.E.Field.3",
+    "F.Foucart.1",
+    "L.E.Kidder.1",
+    "G.Lovelace.1",
+    "E.R.Most.1",
+    "M.Okounkova.2",
+    "R.Owen.2",
+    "H.P.Pfeiffer.1",
+    "M.A.Scheel.1",
+    "Leo.C.Stein.1",
+    "S.A.Teukolsky.1",
+    "Vijay.Varma.1",
+    "A.B.Zimmerman.1",
+
+    # Academic staff
+    "M.Boyle.1",
+    "L.T.Buchman.2",
+    "W.Throwe.2",
+
+    # Postdocs
+    "M.Giesler.1",
+    "G.Lara.2",
+    "O.Long.3",
+    "K.Mitman.1",
+    "Nils.L.Vu.1",
+
+    # Students
+    "K.C.Nelli.1",
+]
+
+############################################################
+
+if __name__ == "__main__":
+    help = """Query INSPIRE for papers by SXS authors updated on a specific date"""
+    parser = argparse.ArgumentParser(
+        description=help, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "--date",
+        default="today",
+        required=False,
+        help="""A date (parsed by dateparser) on which papers were updated on INSPIRE.
+(default: %(default)s)"""
+    )
+
+    args = parser.parse_args()
+
+    date = dateparser.parse(args.date)
+    date_str = date.strftime("%Y-%m-%d")
+
+    au_str = " or ".join([f"author:{id}" for id in sxs_insp_names])
+
+    insp_query = f"find du {date_str} and ({au_str})"
+
+    write_insp_resp_to_md(sxs.utilities.inspire.query(insp_query))


### PR DESCRIPTION
This adds a python script that will generate paper .md's from INSPIRE based on a list of SXS authors' INSPIRE author ids. There is also a workflow file that runs daily and creates a PR if there was an update. ~~We will need a new sxs-org github "app" and private key to be stored in this repo's secrets (as `APP_ID` and `APP_PRIVATE_KEY`) for the PR creation to work.~~ Nevermind, that was only when we wanted actions to run automatically on PRs that were generated by other actions. Here we can just use the default token!