### PR TITLE
Make the news page paginated. Promote to own menu item

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,12 +55,17 @@ plugins:
   - jekyll-titles-from-headings
   - jekyll-sitemap
   - jekyll-redirect-from
+  - jekyll-paginate
 
 sass:
   style: compressed
 
 # Don't add the output extension (.html) to the url of posts
 permalink: /:categories/:year/:month/:day/:title
+
+# Pagination settings
+paginate: 5 # amount of posts to show
+paginate_path: "/news/page:num/"
 
 ### Exclude from processing.
 # The following items will not be processed, by default.

--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,5 +1,8 @@
 - url: /
 
+- url: /news/
+  title: News
+
 - url: /the-science
   title: The Science
   submenu:
@@ -49,7 +52,6 @@
 
 - url: /about-sxs
   submenu:
-    - url: news-and-updates
     - url: motivation
     - url: people
     - url: institutions

--- a/_includes/homepage.html
+++ b/_includes/homepage.html
@@ -106,7 +106,7 @@
             </div>
 
             <div class="has-text-centered">
-                <h2 class="title is-4"><a href="{{ site.baseurl }}/about-sxs/news-and-updates">See previous updates</a></h2>
+                <h2 class="title is-4"><a href="{{ site.baseurl }}/news/">See previous updates</a></h2>
             </div>
 
             <hr>

--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -1,0 +1,76 @@
+{% comment %} LCS Essentially following https://github.com/mmistakes/minimal-mistakes/blob/f3c617f7de2494ecc0ae4d3d8a8e295241b6d0ab/_includes/paginator.html {% endcomment %}
+{% comment %} This only makes sense on a paginating page {% endcomment %}
+{% if paginator.page == 1 %}
+{% assign paginator_base = page.url %}
+{% else %}
+{% assign paginator_base = page.url | split: "/" | pop | join: "/" | append: "/" %}
+{% endif %}
+
+{% if paginator.total_pages > 1 %}
+<nav class="pagination">
+  <ul>
+    {% comment %} Link for previous page {% endcomment %}
+    {% if paginator.previous_page %}
+      {% if paginator.previous_page == 1 %}
+        <li><a href="{{ site.baseurl }}{{ paginator_base }}" class="pagination-previous">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+      {% else %}
+        <li><a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="pagination-previous">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+      {% endif %}
+    {% else %}
+      <li><a href="#" class="pagination-link" disabled><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</span></a></li>
+    {% endif %}
+
+    {% comment %} First page {% endcomment %}
+    {% if paginator.page == 1 %}
+      <li><a href="#" class="pagination-link current" disabled>1</a></li>
+    {% else %}
+      <li><a href="{{ site.baseurl }}{{ paginator_base }}" class="pagination-link">1</a></li>
+    {% endif %}
+
+    {% assign page_start = 2 %}
+    {% if paginator.page > 4 %}
+      {% assign page_start = paginator.page | minus: 2 %}
+      {% comment %} Ellipsis for truncated links {% endcomment %}
+      <li><a href="#" class="pagination-link" disabled>&hellip;</a></li>
+    {% endif %}
+
+    {% assign page_end = paginator.total_pages | minus: 1 %}
+    {% assign pages_to_end = paginator.total_pages | minus: paginator.page %}
+    {% if pages_to_end > 4 %}
+      {% assign page_end = paginator.page | plus: 2 %}
+    {% endif %}
+
+    {% for index in (page_start..page_end) %}
+      {% if index == paginator.page %}
+        <li><a href="{{ site.baseurl }}{{ paginator_base }}page{{ index }}/" class="current pagination-link" disabled>{{ index }}</a></li>
+      {% else %}
+        {% comment %} Distance from current page and this link {% endcomment %}
+        {% assign dist = paginator.page | minus: index %}
+        {% if dist < 0 %}
+          {% comment %} Distance must be a positive value {% endcomment %}
+          {% assign dist = 0 | minus: dist %}
+        {% endif %}
+        <li><a href="{{ site.baseurl }}{{ paginator_base }}page{{ index }}/" class="pagination-link">{{ index }}</a></li>
+      {% endif %}
+    {% endfor %}
+
+    {% comment %} Ellipsis for truncated links {% endcomment %}
+    {% if pages_to_end > 3 %}
+      <li><a href="#" class="pagination-link" disabled>&hellip;</a></li>
+    {% endif %}
+
+    {% if paginator.page == paginator.total_pages %}
+      <li><a href="#" class="pagination-link current" disabled>{{ paginator.page }}</a></li>
+    {% else %}
+      <li><a href="{{ site.baseurl }}{{ paginator_base }}page{{ paginator.total_pages }}/" class="pagination-link">{{ paginator.total_pages }}</a></li>
+    {% endif %}
+
+    {% comment %} Link next page {% endcomment %}
+    {% if paginator.next_page %}
+      <li><a href="{{ site.baseurl }}{{ paginator.next_page_path }}" class="pagination-next">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
+    {% else %}
+      <li><a href="#" class="pagination-next" disabled><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</span></a></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -8,6 +8,29 @@ main {
 .pagination {
     margin-top: 1em;
     clear: both;
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  li {
+    display: block;
+    float: left;
+    margin-left: -1px;
+    a {
+        background-color: $peach;
+        &:hover {
+            background-color: $palepeachsolid;
+        }
+    }
+  }
+
+  a[disabled] {
+      pointer-events: none;
+      cursor: not-allowed;
+  }
 }
 
 .pagination-next, .pagination-previous {

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,17 @@
+---
+layout: page
+title: News and Updates
+---
+
+{% for post in paginator.posts %}
+<h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
+
+<div class="dt-published">
+Created on {{ post.date | date: "%B %-d, %Y" }}
+</div>
+
+<div class="latest-research">{{ post.excerpt }}</div>
+<a href="{{ site.baseurl }}{{ post.url }}">Read more…</a>
+{% endfor %}
+
+{% include paginator.html %}


### PR DESCRIPTION
This puts 'News' at the front of the menu:
![image](https://github.com/user-attachments/assets/01456939-bc24-4d31-abb5-2f74fc653557)
and the News page now has pagination with 5 news items per page:
![image](https://github.com/user-attachments/assets/9af7599f-1d20-41b3-b7de-99810f33833a)

However, now there are three distinct types of next/prev buttons:
- The (static) _pages_ which are paginated via the menu can be reached with their next/prev buttons.
- The (news) _posts_ have next/prev buttons to go between posts in chronological order.
- The _news pages_ (listing the news posts) have the strip of 'Prev, 1, 2 ... N, Next' buttons at bottom.

You can see this deployed at https://duetosymmetry.github.io/www_black-holes_org/ .

Thoughts?