### PR TITLE
Now also query INSPIRE for annual citations to SpEC papers

### DIFF
--- a/_papers/paperStats.py
+++ b/_papers/paperStats.py
@@ -70,6 +70,108 @@ def inspResponseCiteDates(inspResponse):
 
     return np.array(sorted([c['created'] for c in inspResponse]), dtype='datetime64[D]')
 
+def sessionForINSPQueries():
+    """Provide an https session with some default retry settings for repeatedly
+    querying INSPIRE."""
+
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    session = requests.Session()
+
+    ## Retry automatically on certain types of errors
+    retry = Retry(
+        total=10,
+        backoff_factor=0.1,
+        status_forcelist=[
+            413,  # Request Entity Too Large
+            429,  # Too Many Requests
+            500,  # Internal Server Error
+            502,  # Bad Gateway
+            503,  # Service Unavailable
+            504,  # Gateway Timeout
+        ],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+
+    return session
+
+def queryINSPAggregateBuckets(session, recid):
+    """Query the (undocumented but exposed) INSPIRE API "facets"
+    endpoint for getting the aggregate citations "bucket" data for
+    some particular INSPIRE record id.
+    """
+
+    facets_url = "https://inspirehep.net/api/literature/facets"
+    params = { "q": f"refersto:recid:{recid}" }
+
+    response = session.get(facets_url, params=params)
+    if response.status_code != 200:
+        print(f"An error occurred when trying to access <{facets_url}>.", file=sys.stderr)
+        try:
+            print(response.json(), file=sys.stderr)
+        except:
+            pass
+        response.raise_for_status()
+        raise RuntimeError()  # Will only happen if the response was not strictly an error
+
+    try:
+        json_response = response.json()
+    except ValueError:
+        print(f"Response from {url} does not contain valid JSON; returning early.")
+        return None
+
+    return json_response['aggregations']['earliest_date']['buckets']
+
+def inspAggregateBucketsToDict(date_buckets):
+    """Convert INSPIRE buckets data to a normal dict."""
+
+    return {int(d['key_as_string']): d['doc_count'] for d in date_buckets}
+
+def queryINSPSeveralAggregateBuckets(session, yamlMD):
+    """Given some yaml metadata where each item has an 'insp_recid' (INSPIRE
+    record id), query INSPIRE for all of their aggregate citations "bucket"
+    data."""
+
+    return [queryINSPAggregateBuckets(session, v['insp_recid'])
+            for k,v in yamlMD.items()]
+
+def inspJoinSeveralAggregateBucketsToDict(severalBuckets):
+    """Join several papers' worth of INSPIRE aggregate citation "bucket" data
+    into a single dict."""
+
+    citeDicts = list(map(inspAggregateBucketsToDict, severalBuckets))
+    joinedCiteDict = {}
+    for d in citeDicts:
+        for year, count in d.items():
+            oldCount = joinedCiteDict.get(year, 0)
+            newCount = oldCount + count
+            joinedCiteDict[year] = newCount
+    return joinedCiteDict
+
+def bucketDictToVects(bucketDict):
+    """Take a dict derived from bucket data (e.g. from
+    `inspJoinSeveralAggregateBucketsToDict`) and convert it to two numpy
+    vectors. The first is a vector of years, and the second is a vector of
+    citations per year."""
+
+    years = bucketDict.keys()
+    years = np.array(list(map(str, range(min(years),max(years)+1))), dtype='datetime64[Y]')
+    counts = np.zeros(len(years), dtype='int')
+    for k, v in bucketDict.items():
+        y = np.datetime64(str(k))
+        counts[ np.argwhere(years==y) ] = v
+    return years, counts
+
+def citationsPerYearPlot(ax, years, counts, ylabel, rwidth=0.9):
+    """Make a plot of citations per year from years, counts vectors,
+    e.g. returned by `bucketDictToVects`."""
+
+    ax.hist(years, weights=counts, bins=len(years), rwidth=rwidth)
+    ax.set_ylabel(ylabel)
+
 ############################################################
 
 if __name__ == "__main__":
@@ -90,6 +192,7 @@ if __name__ == "__main__":
     datePlot(ax, SpECPaperDates, 'SpEC Publications')
 
     fig.savefig("SpECPaperStats.pdf")
+    fig.savefig("SpECPaperStats.png")
 
     SpECTRECiteQueryResponses = queryINSPreferstoCreatedField(SpECTREPaperYaml)
     SpECTRECiteDates = inspResponseCiteDates(SpECTRECiteQueryResponses)
@@ -100,3 +203,16 @@ if __name__ == "__main__":
     ax.set_yscale("log")
 
     fig.savefig("SpECTREPaperStats.pdf")
+    fig.savefig("SpECTREPaperStats.png")
+
+    ############################################################
+    session = sessionForINSPQueries()
+    SpECAggregates = queryINSPSeveralAggregateBuckets(session, SpECPaperYaml)
+    SpECCiteDict = inspJoinSeveralAggregateBucketsToDict(SpECAggregates)
+    SpECyears, SpECcounts = bucketDictToVects(SpECCiteDict)
+
+    fig, ax = plt.subplots()
+    citationsPerYearPlot(ax, SpECyears, SpECcounts, 'SpEC citations per year')
+
+    fig.savefig("SpECCitationsPerYear.pdf")
+    fig.savefig("SpECCitationsPerYear.png")


### PR DESCRIPTION
We have to use their (undocumented) "facets" API endpoint because of an internal INSPIRE limitation that precludes us from getting all the individual citations to articles with more than 10k citations.