### PR TITLE
Attempt to process PR comments requesting ignoring papers

### DIFF
--- a/.github/workflows/process_ignore_papers_comment.yml
+++ b/.github/workflows/process_ignore_papers_comment.yml
@@ -1,0 +1,45 @@
+# Try to automatically update papers from INSPIRE
+
+name: Process PR comment to ignore papers
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  process-PR-comment:
+
+    # Only run on upstream, not on each fork
+    if: |
+      github.repository_owner == 'sxs-collaboration'
+      && github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/ignore-papers ')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Checkout PR branch
+      run: gh pr checkout ${{ github.event.issue.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Name myself for git commits
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+    - name: Run processIgnorePapers.py
+      run: |
+        cd _papers
+        ARGS=$(echo "${{ github.event.comment.body }}" | sed -E 's|/ignore-papers[[:space:]]+||')
+        python processIgnorePapers.py $ARGS
+    - name: Commit and push changes
+      run: |
+        git commit -m "Ignoring papers request in PR comment" || echo "No changes to commit"
+        git push

--- a/_papers/processIgnorePapers.py
+++ b/_papers/processIgnorePapers.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+from warnings import warn
+
+############################################################
+
+if __name__ == "__main__":
+    help = """Remove one or more bibkeys' markdown files, and add it (them) to
+    the list of papers to ignore."""
+    parser = argparse.ArgumentParser(
+        description=help, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "--ignore-file",
+        type=argparse.FileType('r+'),
+        default="papersToIgnore.txt",
+        required=False,
+        help="""Path to a file with bibkeys to ignore, one bibkey per line.
+(default: %(default)s)"""
+    )
+    parser.add_argument(
+        "bibkeys",
+        nargs='+',
+        help="""INSPIRE bibkey(s) of papers to remove from repo and add to the
+ignore-file."""
+    )
+
+    args = parser.parse_args()
+
+    cur_ignore_bibs = set([line.strip()
+                           for line in args.ignore_file.readlines()])
+
+    new_ignore_bibs = set(args.bibkeys)
+
+    # Warn about those already in the intersection
+    for bibkey in new_ignore_bibs & cur_ignore_bibs:
+        warn(f"skipping bibkey {bibkey}, "
+             f"it's already in {args.ignore_file.name}.")
+
+    new_ignore_bibs = new_ignore_bibs - cur_ignore_bibs
+
+    for bibkey in new_ignore_bibs:
+        # check=True will raise CalledProcessError if not success
+        subprocess.run(['git', 'rm', bibkey + '.md'], check=True)
+        args.ignore_file.write(bibkey + '\n')
+
+    args.ignore_file.flush()
+    args.ignore_file.close()
+
+    # Now git add the updated ignore file
+    # check=True will raise CalledProcessError if not success
+    subprocess.run(['git', 'add', args.ignore_file.name], check=True)


### PR DESCRIPTION
This enables being able to comment on a PR with a command:

> /ignore-papers [bibkey1 [bibkey2 [...]]]

which then triggers an action to modify the current PR by removing the markdown file associated with the bibkeys, and append them to papersToIgnore.txt