### PR TITLE
Add Toni to list of further contributions

### DIFF
--- a/for-researchers/spec.md
+++ b/for-researchers/spec.md
@@ -105,6 +105,7 @@ Further contributions to SpEC were made by
 <span class="contrib-name">Fatemeh Nouri</span>,
 <span class="contrib-name">Maria Okounkova</span>,
 <span class="contrib-name">David Radice</span>,
+<span class="contrib-name">Antoni Ramos-Buades</span>,
 <span class="contrib-name">Oliver Rinne</span>,
 <span class="contrib-name">Olivier Sarbach</span>,
 <span class="contrib-name">Deirdre Shoemaker</span>,


### PR DESCRIPTION
This PR adds Antoni Ramos-Buades in alphabetical surname order to the list of further contributors to SpEC in https://github.com/sxs-collaboration/www_black-holes_org/blob/gh-pages/for-researchers/spec.md . 